### PR TITLE
Use Python 3.10.6+

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -42,7 +42,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: "3.8.x"    # MU_CHANGE
+    versionSpec: ">=3.10.6"    # MU_CHANGE
     architecture: "x64"
 
 - script: pip install -r pip-requirements.txt --upgrade

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -20,7 +20,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.8.x'    # MU_CHANGE
+    versionSpec: '>=3.10.6'    # MU_CHANGE
     architecture: 'x64'
 
 - script: pip install -r pip-requirements.txt --upgrade


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3891

Changes the Python version used in pipelines to 3.10.6 or greater
since that version introduces a fix (bp0-47231) for inconsistent
trailing slashes in tarfile longname directories.

This is required for stuart_update to succeed when handling a
web_dependency (e.g. GCC ARM compilers).

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>