### PR TITLE
[CHERRY-PICK] IntelSiliconPkg: Fix DEBUG macros having incorrect number of arguments

### DIFF
--- a/IntelSiliconPkg/Feature/PcieSecurity/IntelPciDeviceSecurityDxe/IntelPciDeviceSecurityDxe.c
+++ b/IntelSiliconPkg/Feature/PcieSecurity/IntelPciDeviceSecurityDxe/IntelPciDeviceSecurityDxe.c
@@ -498,7 +498,7 @@ DoMeasurementsFromDigestRegister (
       DEBUG ((DEBUG_INFO, "\n"));
     }
 
-    DEBUG ((DEBUG_INFO, "ExtendDigestRegister...\n", ExtendDigestRegister));
+    DEBUG ((DEBUG_INFO, "ExtendDigestRegister...\n"));
     ExtendDigestRegister (PciIo, DeviceSecurityPolicy, TcgAlgId, DigestSel, Digest, DeviceSecurityState);
   }
 }

--- a/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/VtdReg.c
+++ b/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/VtdReg.c
@@ -651,7 +651,7 @@ DumpVtdVerRegs (
   IN VTD_VER_REG  *VerReg
   )
 {
-  DEBUG ((DEBUG_INFO, "  VerReg:\n", VerReg->Uint32));
+  DEBUG ((DEBUG_INFO, "   VerReg - 0x%x\n", VerReg->Uint32));
   DEBUG ((DEBUG_INFO, "    Major - 0x%x\n", VerReg->Bits.Major));
   DEBUG ((DEBUG_INFO, "    Minor - 0x%x\n", VerReg->Bits.Minor));
 }
@@ -666,7 +666,7 @@ DumpVtdCapRegs (
   IN VTD_CAP_REG  *CapReg
   )
 {
-  DEBUG ((DEBUG_INFO, "  CapReg:\n", CapReg->Uint64));
+  DEBUG ((DEBUG_INFO, "  CapReg   - 0x%x\n", CapReg->Uint64));
   DEBUG ((DEBUG_INFO, "    ND     - 0x%x\n", CapReg->Bits.ND));
   DEBUG ((DEBUG_INFO, "    AFL    - 0x%x\n", CapReg->Bits.AFL));
   DEBUG ((DEBUG_INFO, "    RWBF   - 0x%x\n", CapReg->Bits.RWBF));
@@ -697,7 +697,7 @@ DumpVtdECapRegs (
   IN VTD_ECAP_REG  *ECapReg
   )
 {
-  DEBUG ((DEBUG_INFO, "  ECapReg:\n", ECapReg->Uint64));
+  DEBUG ((DEBUG_INFO, "  ECapReg  - 0x%x\n", ECapReg->Uint64));
   DEBUG ((DEBUG_INFO, "    C      - 0x%x\n", ECapReg->Bits.C));
   DEBUG ((DEBUG_INFO, "    QI     - 0x%x\n", ECapReg->Bits.QI));
   DEBUG ((DEBUG_INFO, "    DT     - 0x%x\n", ECapReg->Bits.DT));


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4027

Cc: Ray Ni <ray.ni@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Ovais F Pir <ovais.f.pir@intel.com>

Signed-off-by: Deepak Singh <deepakx.singh@intel.com>
Reviewed-by: Isaac Oram <isaac.w.oram@intel.com>
(cherry-picked from commit e12240390fdee2e8910fc2f740dc4ebf8120a201)