### PR TITLE
PeiSmmAccessLib.c: Use a consistent integer type for comparison

### DIFF
--- a/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLib/PeiSmmAccessLib.c
+++ b/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLib/PeiSmmAccessLib.c
@@ -108,7 +108,7 @@ Close (
 {
   SMM_ACCESS_PRIVATE_DATA  *SmmAccess;
   BOOLEAN                  OpenState;
-  UINT8                    Index;
+  UINTN                    Index;
 
   SmmAccess = SMM_ACCESS_PRIVATE_DATA_FROM_THIS (This);
   if (DescriptorIndex >= SmmAccess->NumberRegions) {


### PR DESCRIPTION
## Description

Change for an alert raised by CodeQL.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified CI build

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>