### PR TITLE
[Cherry-pick] IntelFsp2Pkg commits to add support for null UPD pointers

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
@@ -594,37 +594,38 @@ ASM_PFX(TempRamInitApi):
   SAVE_EAX
   SAVE_EDX
 
+  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
+  SAVE_ECX                               ; save UPD param to slot 3 in xmm6
+
   ;
   ; Sec Platform Init
   ;
-  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
   CALL_MMX  ASM_PFX(SecPlatformInit)
   cmp       eax, 0
   jnz       TempRamInitExit
 
   ; Load microcode
   LOAD_ESP
-  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
+  LOAD_ECX
   CALL_MMX  ASM_PFX(LoadMicrocodeDefault)
-  SXMMN     xmm6, 3, eax            ;Save microcode return status in ECX-SLOT 3 in xmm6.
+  SAVE_UCODE_STATUS                 ; Save microcode return status in slot 1 in xmm5.
   ;@note If return value eax is not 0, microcode did not load, but continue and attempt to boot.
 
   ; Call Sec CAR Init
   LOAD_ESP
-  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
+  LOAD_ECX
   CALL_MMX  ASM_PFX(SecCarInit)
   cmp       eax, 0
   jnz       TempRamInitExit
 
   LOAD_ESP
-  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
-  mov       edi, ecx                     ; Save UPD param to EDI for later code use
+  LOAD_ECX
+  mov       edi, ecx                ; Save UPD param to EDI for later code use
   CALL_MMX  ASM_PFX(EstablishStackFsp)
   cmp       eax, 0
   jnz       TempRamInitExit
 
-  LXMMN     xmm6, eax, 3  ;Restore microcode status if no CAR init error from ECX-SLOT 3 in xmm6.
-  SXMMN     xmm6, 3, edi  ;Save FSP-T UPD parameter pointer in ECX-SLOT 3 in xmm6.
+  LOAD_UCODE_STATUS                 ; Restore microcode status if no CAR init error from slot 1 in xmm5.
 
 TempRamInitExit:
   mov       bl, al                  ; save al data in bl

--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspApiEntryT.nasm
@@ -21,7 +21,7 @@ extern   ASM_PFX(PcdGet32 (PcdFspReservedBufferSize))
 ; Following functions will be provided in PlatformSecLib
 ;
 extern ASM_PFX(AsmGetFspBaseAddress)
-extern ASM_PFX(AsmGetFspInfoHeader)
+extern ASM_PFX(AsmGetFspInfoHeaderNoStack)
 ;extern ASM_PFX(LoadMicrocode)    ; @todo: needs a weak implementation
 extern ASM_PFX(SecPlatformInit)   ; @todo: needs a weak implementation
 extern ASM_PFX(SecCarInit)
@@ -160,6 +160,47 @@ endstruc
          RET_ESI_EXT   mm7
 %endmacro
 
+%macro CALL_EDI  1
+
+  mov     edi,  %%ReturnAddress
+  jmp     %1
+%%ReturnAddress:
+
+%endmacro
+
+%macro CALL_EBP 1
+  mov     ebp, %%ReturnAddress
+  jmp     %1
+%%ReturnAddress:
+%endmacro
+
+%macro RET_EBP 0
+  jmp     ebp                           ; restore EIP from EBP
+%endmacro
+
+;
+; Load UPD region pointer in ECX
+;
+global ASM_PFX(LoadUpdPointerToECX)
+ASM_PFX(LoadUpdPointerToECX):
+  ;
+  ; esp + 4 is input UPD parameter
+  ; If esp + 4 is NULL the default UPD should be used
+  ; ecx will be the UPD region that should be used
+  ;
+  mov       ecx, dword [esp + 4]
+  cmp       ecx, 0
+  jnz       ParamValid
+
+  ;
+  ; Fall back to default UPD region
+  ;
+  CALL_EDI  ASM_PFX(AsmGetFspInfoHeaderNoStack)
+  mov       ecx, DWORD [eax + 01Ch]      ; Read FsptImageBaseAddress
+  add       ecx, DWORD [eax + 024h]      ; Get Cfg Region base address = FsptImageBaseAddress + CfgRegionOffset
+ParamValid:
+  RET_EBP
+
 ;
 ; @todo: The strong/weak implementation does not work.
 ;        This needs to be reviewed later.
@@ -187,10 +228,9 @@ endstruc
 global ASM_PFX(LoadMicrocodeDefault)
 ASM_PFX(LoadMicrocodeDefault):
    ; Inputs:
-   ;   esp -> LoadMicrocodeParams pointer
+   ;   ecx -> UPD region contains LoadMicrocodeParams pointer
    ; Register Usage:
-   ;   esp  Preserved
-   ;   All others destroyed
+   ;   All are destroyed
    ; Assumptions:
    ;   No memory available, stack is hard-coded and used for return address
    ;   Executed by SBSP and NBSP
@@ -201,12 +241,9 @@ ASM_PFX(LoadMicrocodeDefault):
    ;
    movd   ebp, mm7
 
+   mov    esp, ecx  ; ECX has been assigned to UPD region
    cmp    esp, 0
    jz     ParamError
-   mov    eax, dword [esp + 4]    ; Parameter pointer
-   cmp    eax, 0
-   jz     ParamError
-   mov    esp, eax
 
    ; skip loading Microcode if the MicrocodeCodeSize is zero
    ; and report error if size is less than 2k
@@ -444,13 +481,15 @@ Done:
 Exit2:
    jmp   ebp
 
-
+;
+; EstablishStackFsp: EDI should be preserved cross this function
+;
 global ASM_PFX(EstablishStackFsp)
 ASM_PFX(EstablishStackFsp):
   ;
   ; Save parameter pointer in edx
   ;
-  mov       edx, dword [esp + 4]
+  mov       edx, ecx   ; ECX has been assigned to UPD region
 
   ;
   ; Enable FSP STACK
@@ -556,38 +595,36 @@ ASM_PFX(TempRamInitApi):
   SAVE_EDX
 
   ;
-  ; Check Parameter
-  ;
-  mov       eax, dword [esp + 4]
-  cmp       eax, 0
-  mov       eax, 80000002h
-  jz        TempRamInitExit
-
-  ;
   ; Sec Platform Init
   ;
+  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
   CALL_MMX  ASM_PFX(SecPlatformInit)
   cmp       eax, 0
   jnz       TempRamInitExit
 
   ; Load microcode
   LOAD_ESP
+  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
   CALL_MMX  ASM_PFX(LoadMicrocodeDefault)
   SXMMN     xmm6, 3, eax            ;Save microcode return status in ECX-SLOT 3 in xmm6.
   ;@note If return value eax is not 0, microcode did not load, but continue and attempt to boot.
 
   ; Call Sec CAR Init
   LOAD_ESP
+  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
   CALL_MMX  ASM_PFX(SecCarInit)
   cmp       eax, 0
   jnz       TempRamInitExit
 
   LOAD_ESP
+  CALL_EBP  ASM_PFX(LoadUpdPointerToECX) ; ECX for UPD param
+  mov       edi, ecx                     ; Save UPD param to EDI for later code use
   CALL_MMX  ASM_PFX(EstablishStackFsp)
   cmp       eax, 0
   jnz       TempRamInitExit
 
   LXMMN     xmm6, eax, 3  ;Restore microcode status if no CAR init error from ECX-SLOT 3 in xmm6.
+  SXMMN     xmm6, 3, edi  ;Save FSP-T UPD parameter pointer in ECX-SLOT 3 in xmm6.
 
 TempRamInitExit:
   mov       bl, al                  ; save al data in bl

--- a/IntelFsp2Pkg/FspSecCore/Ia32/FspHelper.nasm
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/FspHelper.nasm
@@ -7,6 +7,8 @@
 
     SECTION .text
 
+FSP_HEADER_IMGBASE_OFFSET    EQU   1Ch
+
 global ASM_PFX(FspInfoHeaderRelativeOff)
 ASM_PFX(FspInfoHeaderRelativeOff):
    DD    0x12345678               ; This value must be patched by the build script
@@ -14,7 +16,7 @@ ASM_PFX(FspInfoHeaderRelativeOff):
 global ASM_PFX(AsmGetFspBaseAddress)
 ASM_PFX(AsmGetFspBaseAddress):
    call  ASM_PFX(AsmGetFspInfoHeader)
-   add   eax, 0x1C
+   add   eax, FSP_HEADER_IMGBASE_OFFSET
    mov   eax, dword [eax]
    ret
 

--- a/IntelFsp2Pkg/FspSecCore/Ia32/SaveRestoreSseNasm.inc
+++ b/IntelFsp2Pkg/FspSecCore/Ia32/SaveRestoreSseNasm.inc
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Abstract:
@@ -16,21 +16,21 @@
 ;
 ; Define SSE macros using SSE 4.1 instructions
 ; args 1:XMM, 2:IDX, 3:REG
-%macro SXMMN           3
+%macro SXMMN    3
              pinsrd  %1, %3, (%2 & 3)
              %endmacro
 
 ;
 ;args 1:XMM, 2:REG, 3:IDX
 ;
-%macro LXMMN           3
+%macro LXMMN    3
              pextrd  %2, %1, (%3 & 3)
              %endmacro
 %else
 ;
 ; Define SSE macros using SSE 2 instructions
 ; args 1:XMM, 2:IDX, 3:REG
-%macro SXMMN       3
+%macro SXMMN    3
              pinsrw  %1, %3, (%2 & 3) * 2
              ror     %3, 16
              pinsrw  %1, %3, (%2 & 3) * 2 + 1
@@ -38,19 +38,19 @@
              %endmacro
 
 ;
-;args 1:XMM, 2:REG,  3:IDX
+;args 1:XMM, 2:REG, 3:IDX
 ;
 %macro LXMMN    3
-             pshufd  %1, %1,  ((0E4E4E4h >> (%3 * 2))  & 0FFh)
+             pshufd  %1, %1, ((0E4E4E4h >> (%3 * 2))  & 0FFh)
              movd    %2, %1
-             pshufd  %1, %1,  ((0E4E4E4h >> (%3 * 2 + (%3 & 1) * 4)) & 0FFh)
+             pshufd  %1, %1, ((0E4E4E4h >> (%3 * 2 + (%3 & 1) * 4)) & 0FFh)
              %endmacro
 %endif
 
 ;
-; XMM7 to save/restore EBP, EBX, ESI, EDI
+; XMM7 to save/restore EBP - slot 0, EBX - slot 1, ESI - slot 2, EDI - slot 3
 ;
-%macro SAVE_REGS   0
+%macro SAVE_REGS    0
   SXMMN      xmm7, 0, ebp
   SXMMN      xmm7, 1, ebx
   SXMMN      xmm7, 2, esi
@@ -67,61 +67,65 @@
              %endmacro
 
 ;
-; XMM6 to save/restore EAX, EDX, ECX, ESP
+; XMM6 to save/restore ESP - slot 0, EAX - slot 1, EDX - slot 2, ECX - slot 3
 ;
-%macro LOAD_EAX     0
-  LXMMN      xmm6, eax, 1
+%macro LOAD_ESP    0
+  movd       esp,  xmm6
              %endmacro
 
-%macro SAVE_EAX     0
-  SXMMN      xmm6, 1, eax
-             %endmacro
-
-%macro LOAD_EDX     0
-  LXMMN      xmm6, edx, 2
-             %endmacro
-
-%macro SAVE_EDX     0
-  SXMMN      xmm6, 2, edx
-             %endmacro
-
-%macro SAVE_ECX     0
-  SXMMN      xmm6, 3, ecx
-             %endmacro
-
-%macro LOAD_ECX     0
-  LXMMN      xmm6, ecx, 3
-             %endmacro
-
-%macro SAVE_ESP     0
+%macro SAVE_ESP    0
   SXMMN      xmm6, 0, esp
              %endmacro
 
-%macro LOAD_ESP     0
-  movd       esp,  xmm6
+%macro LOAD_EAX    0
+  LXMMN      xmm6, eax, 1
              %endmacro
+
+%macro SAVE_EAX    0
+  SXMMN      xmm6, 1, eax
+             %endmacro
+
+%macro LOAD_EDX    0
+  LXMMN      xmm6, edx, 2
+             %endmacro
+
+%macro SAVE_EDX    0
+  SXMMN      xmm6, 2, edx
+             %endmacro
+
+%macro LOAD_ECX    0
+  LXMMN      xmm6, ecx, 3
+             %endmacro
+
+%macro SAVE_ECX    0
+  SXMMN      xmm6, 3, ecx
+             %endmacro
+
 ;
-; XMM5 for calling stack
+; XMM5 slot 0 for calling stack
 ; arg 1:Entry
 %macro CALL_XMM       1
              mov     esi, %%ReturnAddress
-             pslldq  xmm5, 4
-%ifdef USE_SSE41_FLAG
-             pinsrd  xmm5, esi, 0
-%else
-             pinsrw  xmm5, esi, 0
-             ror     esi,  16
-             pinsrw  xmm5, esi, 1
-%endif
+             SXMMN   xmm5, 0, esi
              mov     esi,  %1
              jmp     esi
 %%ReturnAddress:
              %endmacro
 
 %macro RET_XMM       0
-             movd    esi, xmm5
-             psrldq  xmm5, 4
+             LXMMN   xmm5, esi, 0
              jmp     esi
+             %endmacro
+
+;
+; XMM5 slot 1 for uCode status
+;
+%macro LOAD_UCODE_STATUS    0
+  LXMMN      xmm5, eax, 1
+             %endmacro
+
+%macro SAVE_UCODE_STATUS    0
+  SXMMN      xmm5, 1, eax
              %endmacro
 
 %macro ENABLE_SSE   0

--- a/IntelFsp2Pkg/FspSecCore/SecFsp.h
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.h
@@ -79,7 +79,7 @@ AsmGetFspBaseAddress (
 /**
   This interface gets FspInfoHeader pointer
 
-  @return   FSP binary base address.
+  @return   FSP info header.
 
 **/
 UINTN

--- a/IntelFsp2Pkg/FspSecCore/SecFsp.h
+++ b/IntelFsp2Pkg/FspSecCore/SecFsp.h
@@ -70,7 +70,7 @@ FspDataPointerFixUp (
   @return   FSP binary base address.
 
 **/
-UINT32
+UINTN
 EFIAPI
 AsmGetFspBaseAddress (
   VOID
@@ -82,7 +82,7 @@ AsmGetFspBaseAddress (
   @return   FSP binary base address.
 
 **/
-UINT32
+UINTN
 EFIAPI
 AsmGetFspInfoHeader (
   VOID

--- a/IntelFsp2Pkg/FspSecCore/SecFspApiChk.c
+++ b/IntelFsp2Pkg/FspSecCore/SecFspApiChk.c
@@ -44,6 +44,8 @@ FspApiCallingCheck (
     //
     if (((UINTN)FspData != MAX_ADDRESS) && ((UINTN)FspData != MAX_UINT32)) {
       Status = EFI_UNSUPPORTED;
+    } else if (ApiParam == NULL) {
+      Status = EFI_SUCCESS;
     } else if (EFI_ERROR (FspUpdSignatureCheck (ApiIdx, ApiParam))) {
       Status = EFI_INVALID_PARAMETER;
     }
@@ -67,9 +69,13 @@ FspApiCallingCheck (
     } else {
       if (FspData->Signature != FSP_GLOBAL_DATA_SIGNATURE) {
         Status = EFI_UNSUPPORTED;
-      } else if (EFI_ERROR (FspUpdSignatureCheck (FspSiliconInitApiIndex, ApiParam))) {
-        Status = EFI_INVALID_PARAMETER;
       } else if (ApiIdx == FspSiliconInitApiIndex) {
+        if (ApiParam == NULL) {
+          Status = EFI_SUCCESS;
+        } else if (EFI_ERROR (FspUpdSignatureCheck (FspSiliconInitApiIndex, ApiParam))) {
+          Status = EFI_INVALID_PARAMETER;
+        }
+
         //
         // Reset MultiPhase NumberOfPhases to zero
         //
@@ -89,6 +95,8 @@ FspApiCallingCheck (
     } else {
       if (FspData->Signature != FSP_GLOBAL_DATA_SIGNATURE) {
         Status = EFI_UNSUPPORTED;
+      } else if (ApiParam == NULL) {
+        Status = EFI_SUCCESS;
       } else if (EFI_ERROR (FspUpdSignatureCheck (FspSmmInitApiIndex, ApiParam))) {
         Status = EFI_INVALID_PARAMETER;
       }

--- a/IntelFsp2Pkg/FspSecCore/X64/FspHelper.nasm
+++ b/IntelFsp2Pkg/FspSecCore/X64/FspHelper.nasm
@@ -7,10 +7,12 @@
     DEFAULT  REL
     SECTION .text
 
+FSP_HEADER_IMGBASE_OFFSET    EQU   1Ch
+
 global ASM_PFX(AsmGetFspBaseAddress)
 ASM_PFX(AsmGetFspBaseAddress):
    call  ASM_PFX(AsmGetFspInfoHeader)
-   add   rax, 0x1C
+   add   rax, FSP_HEADER_IMGBASE_OFFSET
    mov   eax, [rax]
    ret
 

--- a/IntelFsp2Pkg/Include/Library/FspSecPlatformLib.h
+++ b/IntelFsp2Pkg/Include/Library/FspSecPlatformLib.h
@@ -17,10 +17,10 @@
   The callee should not use XMM6/XMM7.
   The return address is saved in MM7.
 
-  @retval in saved in EAX - 0 means platform initialization success.
+  @retval in saved in EAX/RAX - 0 means platform initialization success.
                             other means platform initialization fail.
 **/
-UINT32
+UINTN
 EFIAPI
 SecPlatformInit (
   VOID
@@ -37,10 +37,10 @@ SecPlatformInit (
 
   @param[in] FsptUpdDataPtr     Address pointer to the FSPT_UPD data structure. It is saved in ESP.
 
-  @retval in saved in EAX - 0 means Microcode is loaded successfully.
+  @retval in saved in EAX/RAX - 0 means Microcode is loaded successfully.
                             other means Microcode is not loaded successfully.
 **/
-UINT32
+UINTN
 EFIAPI
 LoadMicrocode (
   IN  VOID  *FsptUpdDataPtr
@@ -56,10 +56,10 @@ LoadMicrocode (
 
   @param[in] FsptUpdDataPtr     Address pointer to the FSPT_UPD data structure. It is saved in ESP.
 
-  @retval in saved in EAX - 0 means CAR initialization success.
+  @retval in saved in EAX/RAX - 0 means CAR initialization success.
                             other means CAR initialization fail.
 **/
-UINT32
+UINTN
 EFIAPI
 SecCarInit (
   IN  VOID  *FsptUpdDataPtr


### PR DESCRIPTION
## Description

Cherry-pick latest tianocore IntelFsp2Pkg commits to add support for null UPD pointers.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a physical intel platform.

## Integration Instructions

N/A
