### PR TITLE
 [Cherry-pick] IntelSiliconPkg/SpiFvbServiceSmm: Rewrite VariableStore header [Rebase & FF]

### DIFF
--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceCommon.c
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceCommon.c
@@ -574,6 +574,28 @@ GetVariableFvInfo (
     return;
   }
 
+  //
+  // GetVariableFlashNvStorageInfo () only reports regular variable region information,
+  // if platform implemented an additional NVS region following the regular variable region,
+  // then both region size should be included as overall NVS region size.
+  //
+  // The below PcdFlashNvStorageAdditionalSize is for compatible with legacy usages that should be deprecated.
+  // The new usage model should define separate regions without implicit connections to UEFI Variable or FTW regions.
+  //
+  // Example NVS flash map for such legacy usage:
+  // Note: PcdFlashNvStorageAdditionalSize is equal to platform PcdFlashFvNvStorageEventLogSize.
+  //  ---------------
+  //  |UEFI Variable|
+  //  ---------------
+  //  |EventLog     | <= this is Additional NVS region
+  //  ---------------
+  //  |FTW Working  |
+  //  ---------------
+  //  |FTW Spare    |
+  //  ---------------
+  //
+  NvStoreLength += PcdGet32 (PcdFlashNvStorageAdditionalSize);
+
   Status = GetVariableFlashFtwSpareInfo (&NvBaseAddress, &Length64);
   if (!EFI_ERROR (Status)) {
     // Stay within the current UINT32 size assumptions in the variable stack.

--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceMm.c
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceMm.c
@@ -106,22 +106,22 @@ FvbInitialize (
   VOID
   )
 {
-  EFI_FVB_INSTANCE                      *FvbInstance;
-  EFI_FIRMWARE_VOLUME_HEADER            *FvHeader;
-  EFI_FV_BLOCK_MAP_ENTRY                *PtrBlockMapEntry;
-  EFI_PHYSICAL_ADDRESS                  BaseAddress;
-  EFI_STATUS                            Status;
-  UINTN                                 BufferSize;
-  UINTN                                 Idx;
-  UINT32                                MaxLbaSize;
-  UINT32                                BytesWritten;
-  UINTN                                 BytesErased;
-  EFI_PHYSICAL_ADDRESS                  NvStorageBaseAddress;
-  UINT64                                NvStorageFvSize;
-  UINT32                                ExpectedBytesWritten;
-  VARIABLE_STORE_HEADER                 *VariableStoreHeader;
-  UINT8                                 VariableStoreType;
-  UINT8                                 *NvStoreBuffer;
+  EFI_FVB_INSTANCE            *FvbInstance;
+  EFI_FIRMWARE_VOLUME_HEADER  *FvHeader;
+  EFI_FV_BLOCK_MAP_ENTRY      *PtrBlockMapEntry;
+  EFI_PHYSICAL_ADDRESS        BaseAddress;
+  EFI_STATUS                  Status;
+  UINTN                       BufferSize;
+  UINTN                       Idx;
+  UINT32                      MaxLbaSize;
+  UINT32                      BytesWritten;
+  UINTN                       BytesErased;
+  EFI_PHYSICAL_ADDRESS        NvStorageBaseAddress;
+  UINT64                      NvStorageFvSize;
+  UINT32                      ExpectedBytesWritten;
+  VARIABLE_STORE_HEADER       *VariableStoreHeader;
+  UINT8                       VariableStoreType;
+  UINT8                       *NvStoreBuffer;
 
   Status = GetVariableFlashNvStorageInfo (&BaseAddress, &NvStorageFvSize);
   if (EFI_ERROR (Status)) {
@@ -137,6 +137,7 @@ FvbInitialize (
     DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage base address not supported.\n", __FUNCTION__));
     return;
   }
+
   NvStorageBaseAddress = mPlatformFvBaseAddress[0].FvBase;
 
   Status = SafeUint64ToUint32 (NvStorageFvSize, &mPlatformFvBaseAddress[0].FvSize);
@@ -145,6 +146,7 @@ FvbInitialize (
     DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage size not supported.\n", __FUNCTION__));
     return;
   }
+
   NvStorageFvSize = mPlatformFvBaseAddress[0].FvSize;
 
   mPlatformFvBaseAddress[1].FvBase = PcdGet32 (PcdFlashMicrocodeFvBase);
@@ -236,7 +238,7 @@ FvbInitialize (
             //
             // Initialize common VariableStore header fields
             //
-            VariableStoreHeader->Size      = (UINT32) (NvStorageFvSize - FvHeader->HeaderLength);
+            VariableStoreHeader->Size      = (UINT32)(NvStorageFvSize - FvHeader->HeaderLength);
             VariableStoreHeader->Format    = VARIABLE_STORE_FORMATTED;
             VariableStoreHeader->State     = VARIABLE_STORE_HEALTHY;
             VariableStoreHeader->Reserved  = 0;
@@ -262,6 +264,7 @@ FvbInitialize (
 
           continue;
         }
+
         if (BytesWritten != ExpectedBytesWritten) {
           DEBUG ((DEBUG_WARN, "ERROR - BytesWritten != ExpectedBytesWritten\n"));
           DEBUG ((DEBUG_INFO, " BytesWritten = 0x%X\n ExpectedBytesWritten = 0x%X\n", BytesWritten, ExpectedBytesWritten));

--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
@@ -43,9 +43,10 @@
   IntelSiliconPkg/IntelSiliconPkg.dec
 
 [Pcd]
-  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase         ## CONSUMES
-  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize         ## CONSUMES
-  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType       ## SOMETIMES_CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase            ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize            ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType          ## SOMETIMES_CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashNvStorageAdditionalSize    ## CONSUMES
 
 [Sources]
   FvbInfo.c

--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceSmm.inf
@@ -45,6 +45,7 @@
 [Pcd]
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase         ## CONSUMES
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize         ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType       ## SOMETIMES_CONSUMES
 
 [Sources]
   FvbInfo.c
@@ -61,6 +62,8 @@
 [Guids]
   gEfiFirmwareFileSystem2Guid                   ## CONSUMES
   gEfiSystemNvDataFvGuid                        ## CONSUMES
+  gEfiVariableGuid                              ## SOMETIMES_CONSUMES
+  gEfiAuthenticatedVariableGuid                 ## SOMETIMES_CONSUMES
 
 [Depex]
   TRUE

--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
@@ -44,6 +44,8 @@
 [Pcd]
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvBase         ## CONSUMES
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashMicrocodeFvSize         ## CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType       ## SOMETIMES_CONSUMES
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashNvStorageAdditionalSize ## CONSUMES
 
 [Sources]
   FvbInfo.c
@@ -60,6 +62,8 @@
 [Guids]
   gEfiFirmwareFileSystem2Guid                   ## CONSUMES
   gEfiSystemNvDataFvGuid                        ## CONSUMES
+  gEfiVariableGuid                              ## SOMETIMES_CONSUMES
+  gEfiAuthenticatedVariableGuid                 ## SOMETIMES_CONSUMES
 
 [Depex]
   TRUE

--- a/IntelSiliconPkg/IntelSiliconPkg.dec
+++ b/IntelSiliconPkg/IntelSiliconPkg.dec
@@ -184,7 +184,8 @@
 
   ## Define Flash Variable Store type.<BR><BR>
   #  When Flash Variable Store corruption happened, the SpiFvbService will recreate Variable Store
-  #  with valid header information provided by this PCD value.<BR>
+  #  with valid header information provided by this PCD value.
+  #  Note: This PCD must be FixedAtBuild when using Standalone MM.
   #  0: Variable Store is gEfiVariableGuid type.<BR>
   #  1: Variable Store is gEfiAuthenticatedVariableGuid type.<BR>
   #  Other value: reserved for future use.<BR>
@@ -195,6 +196,7 @@
   #  Platform may implement a Regular variable region and an additional region, which will require this PCD
   #  to tell SpiFvbService to include both regions.
   #  Note: This PCD is for compatible with legacy usages that should be deprecated.
+  #  Note: This PCD must be FixedAtBuild when using Standalone MM.
   #  The new usage model should define separate regions without implicit connections to UEFI Variable or FTW regions.<BR>
   #  Example legacy usage is to set this PCD equal to platform PcdFlashFvNvStorageEventLogSize.
   #  0: No additional NVS region.<BR>

--- a/IntelSiliconPkg/IntelSiliconPkg.dec
+++ b/IntelSiliconPkg/IntelSiliconPkg.dec
@@ -182,3 +182,11 @@
   # @Prompt The VTd PEI DMA buffer size for S3.
   gIntelSiliconPkgTokenSpaceGuid.PcdVTdPeiDmaBufferSizeS3|0x00200000|UINT32|0x00000004
 
+  ## Define Flash Variable Store type.<BR><BR>
+  #  When Flash Variable Store corruption happened, the SpiFvbService will recreate Variable Store
+  #  with valid header information provided by this PCD value.<BR>
+  #  0: Variable Store is gEfiVariableGuid type.<BR>
+  #  1: Variable Store is gEfiAuthenticatedVariableGuid type.<BR>
+  #  Other value: reserved for future use.<BR>
+  # @Prompt Flash Variable Store type.
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType|0x00|UINT8|0x0000000E

--- a/IntelSiliconPkg/IntelSiliconPkg.dec
+++ b/IntelSiliconPkg/IntelSiliconPkg.dec
@@ -190,3 +190,14 @@
   #  Other value: reserved for future use.<BR>
   # @Prompt Flash Variable Store type.
   gIntelSiliconPkgTokenSpaceGuid.PcdFlashVariableStoreType|0x00|UINT8|0x0000000E
+
+  ## Declares Additional NVS Region Size.<BR><BR>
+  #  Platform may implement a Regular variable region and an additional region, which will require this PCD
+  #  to tell SpiFvbService to include both regions.
+  #  Note: This PCD is for compatible with legacy usages that should be deprecated.
+  #  The new usage model should define separate regions without implicit connections to UEFI Variable or FTW regions.<BR>
+  #  Example legacy usage is to set this PCD equal to platform PcdFlashFvNvStorageEventLogSize.
+  #  0: No additional NVS region.<BR>
+  #  non-zero: The size of an additional NVS region following the Regular variable region.<BR>
+  # @Prompt Additional NVS Region Size.
+  gIntelSiliconPkgTokenSpaceGuid.PcdFlashNvStorageAdditionalSize|0x00000000|UINT32|0x0000000F


### PR DESCRIPTION
## Description

4 patch PR series.

---

### Patch 1: [Cherry-pick] IntelSiliconPkg/SpiFvbServiceSmm: Rewrite VariableStore header. 

When invalid VariableStore FV header detected, current SpiFvbService
will erase both FV and VariableStore headers from flash, however,
it will only rewrite FV header back and cause invalid VariableStore
header.

This patch adding the support for rewriting both FV header and
VariableStore header when VariableStore corruption happened.
The Corrupted variable content should be taken care by
FaultTolerantWrite driver later.

Platform has to set PcdFlashVariableStoreType to inform SpiFvbService
which VariableStoreType should be rewritten.

Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: S, Ashraf Ali <ashraf.ali.s@intel.com>
Reviewed-by: Isaac Oram <isaac.w.oram@intel.com>
(cherry picked from commit e95c7988994c73918ffa282e2d2f5af11f8addc4)

---

### Patch 2: [Cherry-pick] IntelSiliconPkg/SpiFvbServiceSmm: Support Additional NVS region. 

Platform may implement an additional NVS region following
Regular variable region and in this case SpiFvbService should include
both region size when calculating the total NVS region size.

The PcdFlashNvStorageAdditionalSize is for compatible with legacy
usages that should be deprecated. The new usage model should define
separate regions without implicit connections to UEFI Variable or
FTW regions.

Example NVS flash map for such legacy usage:
Note: PcdFlashNvStorageAdditionalSize is equal to platform
      PcdFlashFvNvStorageEventLogSize.

```
  ---------------
  |UEFI Variable|
  ---------------
  |EventLog     | <= this is Additional NVS region
  ---------------
  |FTW Working  |
  ---------------
  |FTW Spare    |
  ---------------
```

Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Chasel Chiu <chasel.chiu@intel.com>
Reviewed-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Isaac Oram <isaac.w.oram@intel.com>
(cherry picked from commit 88d44c563d9fd5c95be93e706f9420352ee4c053)

---

### Patch 3: Mu Change: Uncrustify

---

### Patch 4: [Cherry-pick] SpiFvbServiceStandaloneMm: Add changes for rewrite varstore header

Updates the Standalone MM module to have the necessary INF changes
to build with the following two recent commits made to rewrite the
the variable store header in the MM SPI FVB service.

  - e95c798
  - 88d44c5

Cc: Ashraf Ali S <ashraf.ali.s@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Chasel Chiu <chasel.chiu@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Isaac Oram <isaac.w.oram@intel.com>
Reviewed-by: Chasel Chiu <chasel.chiu@intel.com>
(cherry picked from commit e2353ad640d55dafb7315eae2a93b318809ccbe3)

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified in Intel upstream edk2-platforms testing.

## Integration Instructions

N/A