### PR TITLE
[CHERRY-PICK] Fix FV header length (#9)

### DIFF
--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/FvbInfo.c
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/FvbInfo.c
@@ -115,7 +115,7 @@ GetFvbInfo (
     Status = mFvbMediaInfoGenerators[Index](&FvbMediaInfo);
     ASSERT_EFI_ERROR (Status);
     if (!EFI_ERROR (Status) && (FvbMediaInfo.BaseAddress == FvBaseAddress)) {
-      FvHeader = AllocateCopyPool (sizeof (EFI_FIRMWARE_VOLUME_HEADER), &FvbMediaInfo.FvbInfo);
+      FvHeader = AllocateCopyPool ((FvbMediaInfo.FvbInfo.HeaderLength), &FvbMediaInfo.FvbInfo);
 
       //
       // Update the checksum value of FV header.


### PR DESCRIPTION
## Description

Cherry-pick from release/202202 (commit [d484285](https://github.com/microsoft/mu_silicon_intel_tiano/commit/d48428521021faccbff10652123a4fa4bf1d2eff)).

Read FV header length from the header instead of using
`sizeof(EFI_FIRMWARE_VOLUME_HEADER)` to account for variable number
of block map entries.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

(cherry-pick from release/202202)

## Integration Instructions

N/A other than including this change.