### PR TITLE
[CHERRY-PICK] Take changes from 202208 into 202302 [Rebase & FF]

### DIFF
--- a/IntelSiliconPkg/Feature/Flash/SpiFvbService/FvbInfo.c
+++ b/IntelSiliconPkg/Feature/Flash/SpiFvbService/FvbInfo.c
@@ -115,7 +115,7 @@ GetFvbInfo (
     Status = mFvbMediaInfoGenerators[Index](&FvbMediaInfo);
     ASSERT_EFI_ERROR (Status);
     if (!EFI_ERROR (Status) && (FvbMediaInfo.BaseAddress == FvBaseAddress)) {
-      FvHeader = AllocateCopyPool (FvbMediaInfo.FvbInfo.HeaderLength, &FvbMediaInfo.FvbInfo);
+      FvHeader = AllocateCopyPool ((FvbMediaInfo.FvbInfo.HeaderLength), &FvbMediaInfo.FvbInfo);
 
       //
       // Update the checksum value of FV header.

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library==0.15.0
-edk2-pytool-extensions~=0.23.2 # MU_CHANGE
+edk2-pytool-extensions~=0.23.3 # MU_CHANGE
 edk2-basetools==0.1.48
 antlr4-python3-runtime==4.13.0
 lcov-cobertura==2.0.2

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -15,6 +15,6 @@
 edk2-pytool-library==0.15.0
 edk2-pytool-extensions~=0.23.2 # MU_CHANGE
 edk2-basetools==0.1.48
-antlr4-python3-runtime==4.12.0
+antlr4-python3-runtime==4.13.0
 lcov-cobertura==2.0.2
 regex

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.14.1
+edk2-pytool-library==0.15.0
 edk2-pytool-extensions~=0.23.2 # MU_CHANGE
 edk2-basetools==0.1.48
 antlr4-python3-runtime==4.12.0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,7 +14,7 @@
 
 edk2-pytool-library==0.14.1
 edk2-pytool-extensions~=0.23.2 # MU_CHANGE
-edk2-basetools==0.1.45
+edk2-basetools==0.1.48
 antlr4-python3-runtime==4.12.0
 lcov-cobertura==2.0.2
 regex


### PR DESCRIPTION
## Description

Cherry-picked changes from 202208 into 202302.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Built and booted a physical platform with these changes.

## Integration Instructions

N/A