### PR TITLE
IntelSiliconPkg/PeiSmmAccessLibSmramc: Use consistent integer width i…

### DIFF
--- a/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLibSmramc/PeiSmmAccessLib.c
+++ b/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLibSmramc/PeiSmmAccessLib.c
@@ -81,7 +81,7 @@ Open (
   )
 {
   SMM_ACCESS_PRIVATE_DATA  *SmmAccess;
-  UINT8                    Index;
+  UINTN                    Index;  // MU_CHANGE - Use consistent width in loop comparison
   UINT64                   Address;
   UINT8                    SmramControl;
 
@@ -162,7 +162,7 @@ Close (
 {
   SMM_ACCESS_PRIVATE_DATA  *SmmAccess;
   BOOLEAN                  OpenState;
-  UINT8                    Index;
+  UINTN                    Index;   // MU_CHANGE - Use consistent width in loop comparison
   UINT64                   Address;
   UINT8                    SmramControl;
 


### PR DESCRIPTION
Fixes #104

Updates the code in this library instance (`PeiSmmAccessLibSmramc`)
to have the same integer width fixes already in the other library
instance (`PeiSmmAccessLib`).

Resolves CodeQL Rule ID `cpp/comparison-with-wider-type`:

  In a loop condition, comparison of a value of a narrow type with a
  value of a wide type may result in unexpected behavior if the wider
  value is sufficiently large (or small). This is because the
  narrower value may overflow. This can lead to an infinite loop.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build IntelSiliconPkg. Change is already in equivalent library instance.

## Integration Instructions

N/A