### PR TITLE
.git-blame-ignore-revs: Ignore Line Ending and Uncrustify only commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,23 @@
+###################################################
+# Line Ending Only Changes                        #
+###################################################
+# Fixed new line endings being LF instead of CRLF
+53954a8aba9aeca7c784fad5bcce0b2015f330ea
+# Fix line endings in repo (LF -> CRLF)
+18949932d64eff23d78934a897ce7ff1ec1b2845
+# IntelFsp2WrapperPkg: Convert files to CRLF line ending
+ca467f68f4ce520ad0250678c91e9623a0195902
+# IntelFsp2Pkg: Convert files to CRLF line ending
+4aabee6980fb60aecc58e750560205abcf681236
+
+###################################################
+# Code Formatting (Uncrustify) Only Changes       #
+###################################################
+# Mu Change: Uncrustify
+ab8572f969c2c8c7bd7d64e0510245214d2a67eb
+# Ran uncrustify on the repo to get it to meet our coding standards
+e0ac3003f94c8abe3c1ebdbd4505b055814ca09c
+# IntelFsp2WrapperPkg: Apply uncrustify changes
+7c7184e201a90a1d2376e615e55e3f4074731468
+# IntelFsp2Pkg: Apply uncrustify changes
+111f2228ddf487b0ac3491e416bb3dcdcfa4f979


### PR DESCRIPTION
## Description

Adds commits that only applied Uncrustify formatting or converted
line endings to a .git-blame-ignore-revs file so they are ignored
by git blame. This is supported by GitHub:
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/

This helps clean up git blame by filtering out these changes.

Note: This file needs to be updated on rebase branches. Processes
      like filter-branch can automatically update relevant SHAs.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- `git blame`

## Integration Instructions

N/A