### PR TITLE
Updated CISettings.py to use the edk2toolext codeql helpers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -271,7 +271,9 @@ jobs:
         from pathlib import Path
 
         # Find the plugin directory that contains the CodeQL plugin
-        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('BaseTools/Plugin/CodeQL'))
+        if not plugin_dir:
+          plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CodeQL'))
 
         # This should only be found once
         if len(plugin_dir) == 1:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -319,10 +319,32 @@ jobs:
       if: steps.codeqlcli_cache.outputs.cache-hit != 'true'
       run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --codeql
 
+    - name: Find pytool Plugin Directory
+      id: find_pytool_dir
+      shell: python
+      run: |
+        import os
+        import sys
+        from pathlib import Path
+
+        # Find the plugin directory that contains the Compiler plugin
+        plugin_dir = list(Path(os.environ['GITHUB_WORKSPACE']).rglob('.pytool/Plugin/CompilerPlugin'))
+
+        # This should only be found once
+        if len(plugin_dir) == 1:
+            # If the directory is found get the parent Plugin directory
+            plugin_dir = str(plugin_dir[0].parent)
+
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'pytool_plugin_dir={plugin_dir}', file=fh)
+        else:
+            print("::error title=Workspace Error!::Failed to find Mu Basecore .pytool/Plugin directory!")
+            sys.exit(1)
+
     - name: Remove CI Plugins Irrelevant to CodeQL
       shell: python
       env:
-        CODEQL_PLUGIN_DIR: ${{ steps.find_dir.outputs.codeql_plugin_dir }}
+        PYTOOL_PLUGIN_DIR: ${{ steps.find_pytool_dir.outputs.pytool_plugin_dir }}
       run: |
         import os
         import shutil
@@ -331,7 +353,7 @@ jobs:
         # Only these two plugins are needed for CodeQL
         plugins_to_keep = ['CodeQL', 'CompilerPlugin']
 
-        plugin_dir = Path(os.environ['CODEQL_PLUGIN_DIR']).parent.absolute()
+        plugin_dir = Path(os.environ['PYTOOL_PLUGIN_DIR']).absolute()
         if plugin_dir.is_dir():
             for dir in plugin_dir.iterdir():
                 if str(dir.stem) not in plugins_to_keep:

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -18,14 +18,7 @@ from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import GetHostInfo
 from pathlib import Path
 
-try:
-    # May not be present until submodules are populated
-    root = Path(__file__).parent.parent.resolve()
-    sys.path.append(str(root/'MU_BASECORE'/'.pytool'/'Plugin'/'CodeQL'/'integration'))
-    import stuart_codeql as codeql_helpers
-except ImportError:
-    pass
-
+from edk2toolext import codeql as codeql_helpers
 
 # MU_CHANGE - Add CiSetupSettingsManager superclass.
 class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManager, PrEvalSettingsManager):


### PR DESCRIPTION
## Description

The 202311 rebase moved the codeql plugin from .pytool to Basetools.  This requires a change in CISettings.py to reference the correct codeql helper functions.  Instead of using the internal versions we instead move to the edk2 pytool extensions version.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with CI.

## Integration Instructions

N/A
