### PR TITLE
[Rebase & FF] [Cherry-pick] Get all the missing commits from 202302 into 202311

### DIFF
--- a/.azurepipelines/MuDevOpsWrapper.yml
+++ b/.azurepipelines/MuDevOpsWrapper.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: microsoft
       name: microsoft/mu_devops
-      ref: refs/tags/v9.0.1
+      ref: refs/tags/v9.1.1
 
 parameters:
 - name: do_ci_build

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,7 +23,11 @@ on:
 
 jobs:
   approval_check:
+
+    permissions:
+      pull-requests: write
+
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@v9.0.1
+    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@v9.1.1
     secrets: inherit

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,7 +24,13 @@ on:
 
 jobs:
   merge_check:
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@v9.0.1
+    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@v9.1.1
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -185,7 +185,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.8
+      uses: robinraju/release-downloader@v1.9
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -178,7 +178,7 @@ jobs:
 
     - name: Attempt to Load cargo-make From Cache
       id: cargo_make_cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.get_cargo_tool_details.outputs.cargo_bin_path }}
         key: ${{ steps.get_cargo_tool_details.outputs.cargo_make_cache_key }}
@@ -312,7 +312,7 @@ jobs:
 
     - name: Attempt to Load CodeQL CLI From Cache
       id: codeqlcli_cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
         key: ${{ steps.cache_key_gen.outputs.codeql_cli_cache_key }}

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -18,4 +18,9 @@ on:
 
 jobs:
   apply:
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v9.0.1
+
+    permissions:
+      contents: read
+      issues: write
+
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v9.1.1

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -31,4 +31,9 @@ on:
 
 jobs:
   apply:
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v9.0.1
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v9.1.1

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -24,4 +24,8 @@ on:
 
 jobs:
   sync:
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v9.0.1
+
+    permissions:
+      issues: write
+
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v9.1.1

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -23,6 +23,11 @@ on:
 jobs:
   validate_pr:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - run: |
           prTitle="$(gh api graphql -F owner=$OWNER -F name=$REPO -F pr_number=$PR_NUMBER -f query='

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -27,5 +27,10 @@ on:
 
 jobs:
   draft:
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v9.0.1
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v9.1.1
     secrets: inherit

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -24,6 +24,11 @@ on:
 jobs:
   repo_cleanup:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      issues: write
+
     steps:
       - name: Get Repository Info
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,4 +24,9 @@ on:
 
 jobs:
   check:
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v9.0.1
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v9.1.1

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -19,4 +19,8 @@ on:
 
 jobs:
   triage:
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v9.0.1
+
+    permissions:
+      issues: write
+
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v9.1.1

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.19.9
-edk2-pytool-extensions~=0.26.4 # MU_CHANGE
+edk2-pytool-library==0.20.0
+edk2-pytool-extensions~=0.27.0
 edk2-basetools==0.1.49
 antlr4-python3-runtime==4.13.1
 lcov-cobertura==2.0.2


### PR DESCRIPTION
## Description

Cherry-pick the commits from 202302 that are missing from 202311 since the creation of the release branch.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
