### PR TITLE
[REBASE&FF][202405] One-off Cherry-picks from 202311

### DIFF
--- a/IntelFsp2Pkg/Tools/fsp_tools_path_env.json
+++ b/IntelFsp2Pkg/Tools/fsp_tools_path_env.json
@@ -1,0 +1,4 @@
+{
+  "scope": "fsptools",
+  "flags": ["set_path", "set_pypath"]
+}

--- a/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLibSmramc/PeiSmmAccessLib.c
+++ b/IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLibSmramc/PeiSmmAccessLib.c
@@ -81,7 +81,7 @@ Open (
   )
 {
   SMM_ACCESS_PRIVATE_DATA  *SmmAccess;
-  UINT8                    Index;
+  UINTN                    Index;  // MU_CHANGE - Use consistent width in loop comparison
   UINT64                   Address;
   UINT8                    SmramControl;
 
@@ -162,7 +162,7 @@ Close (
 {
   SMM_ACCESS_PRIVATE_DATA  *SmmAccess;
   BOOLEAN                  OpenState;
-  UINT8                    Index;
+  UINTN                    Index;   // MU_CHANGE - Use consistent width in loop comparison
   UINT64                   Address;
   UINT8                    SmramControl;
 


### PR DESCRIPTION
## Description

Applies multiple One-off Project Mu Cherry-picks from 202311

includes:
- https://github.com/microsoft/mu_silicon_intel_tiano/commit/4b7a2b8767
- https://github.com/microsoft/mu_silicon_intel_tiano/commit/94136ac234

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Cherry-pick from 202311

## Integration Instructions

Cherry-pick from 202311
