### PR TITLE
IntelSiliconPkg: Add BaseSmmAccessLibNull

### DIFF
--- a/IntelSiliconPkg/Feature/SmmAccess/Library/BaseSmmAccessLibNull/BaseSmmAccessLibNull.c
+++ b/IntelSiliconPkg/Feature/SmmAccess/Library/BaseSmmAccessLibNull/BaseSmmAccessLibNull.c
@@ -1,0 +1,35 @@
+/** @file
+  A NULL library instance of SmmAccessLib.
+
+  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// MU_CHANGE - WHOLE FILE - TCBZ3540
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/SmmAccessLib.h>
+
+/**
+  This function is to install an SMM Access PPI
+
+  @retval EFI_SUCCESS           - Ppi successfully started and installed.
+  @retval EFI_NOT_FOUND         - Ppi can't be found.
+  @retval EFI_OUT_OF_RESOURCES  - Ppi does not have enough resources to initialize the driver.
+  @retval EFI_UNSUPPORTED       - The PPI was not installed and installation is unsupported in
+                                  this instance of function implementation.
+
+**/
+EFI_STATUS
+EFIAPI
+PeiInstallSmmAccessPpi (
+  VOID
+  )
+{
+  ASSERT (FALSE);
+  return EFI_UNSUPPORTED;
+}

--- a/IntelSiliconPkg/Feature/SmmAccess/Library/BaseSmmAccessLibNull/BaseSmmAccessLibNull.inf
+++ b/IntelSiliconPkg/Feature/SmmAccess/Library/BaseSmmAccessLibNull/BaseSmmAccessLibNull.inf
@@ -1,0 +1,28 @@
+## @file
+# A NULL library instance of SmmAccessLib.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+# MU_CHANGE - WHOLE FILE - TCBZ3540
+
+[Defines]
+INF_VERSION     = 0x00010017
+BASE_NAME       = BaseSmmAccessLibNull
+FILE_GUID       = C1A14AB6-B757-4046-9B92-9DCE1A2154C6
+VERSION_STRING  = 1.0
+MODULE_TYPE     = BASE
+LIBRARY_CLASS   = SmmAccessLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IntelSiliconPkg/IntelSiliconPkg.dec
+
+[LibraryClasses]
+  DebugLib
+
+[Sources]
+  BaseSmmAccessLibNull.c

--- a/IntelSiliconPkg/IntelSiliconPkg.dsc
+++ b/IntelSiliconPkg/IntelSiliconPkg.dsc
@@ -127,6 +127,7 @@
   IntelSiliconPkg/Library/IntelVTdPeiDxeLib/IntelVTdPeiDxeLib.inf
   IntelSiliconPkg/Library/IntelVTdPeiDxeLib/IntelVTdPeiDxeLibExt.inf
 
+  IntelSiliconPkg/Feature/SmmAccess/Library/BaseSmmAccessLibNull/BaseSmmAccessLibNull.inf   # MU_CHANGE - TCBZ3540
   IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLib/PeiSmmAccessLib.inf
   IntelSiliconPkg/Feature/SmmAccess/Library/PeiSmmAccessLibSmramc/PeiSmmAccessLib.inf
   IntelSiliconPkg/Feature/SmmAccess/SmmAccessDxe/SmmAccess.inf


### PR DESCRIPTION
## Description

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3540

Adds a NULL instance of SmmAccessLib.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Rangasai V Chaganty <rangasai.v.chaganty@intel.com>

Cherry-picked from https://github.com/microsoft/mu_silicon_intel_tiano/commit/ff0c71d9b1bf8e65d52fe595f5cc686e3ca9c4a8. Missed initially because cleansing fire marked it as 0 lines changed due to line endings changing the file entirely. Line endings for new file were added as CRLF to minimize churn and allow for correct line endings from the start.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.