### PR TITLE
IntelVtdDxe: Replace custom identifier with INMODULE markers

### DIFF
--- a/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.c
+++ b/IntelSiliconPkg/Feature/VTd/IntelVTdDxe/IntelVTdDxe.c
@@ -232,7 +232,7 @@ VTdSetAttribute (
   UINT16         Segment;
   VTD_SOURCE_ID  SourceId;
   CHAR8          PerfToken[sizeof ("VTD(S0000.B00.D00.F00)")];
-  UINT32         Identifier;
+  // UINT32         Identifier; // MU_CHANGE - Remove custom perf identifier
 
   DumpVtdIfError ();
 
@@ -259,18 +259,23 @@ VTdSetAttribute (
 
     Status = RequestAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
   } else {
-    PERF_CODE (
-      AsciiSPrint (PerfToken, sizeof (PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
-      Identifier = (Segment << 16) | SourceId.Uint16;
-      PERF_START_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
-      );
+    // MU_CHANGE Begin - Remove custom perf identifier
+    // PERF_CODE (
+    //   AsciiSPrint (PerfToken, sizeof (PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
+    //   Identifier = (Segment << 16) | SourceId.Uint16;
+    //   PERF_START_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
+    //   );
 
+    AsciiSPrint (PerfToken, sizeof(PerfToken), "S%04xB%02xD%02xF%01x", Segment, SourceId.Bits.Bus, SourceId.Bits.Device, SourceId.Bits.Function);
+    PERF_INMODULE_BEGIN(PerfToken);
     Status = SetAccessAttribute (Segment, SourceId, DeviceAddress, Length, IoMmuAccess);
 
-    PERF_CODE (
-      Identifier = (Segment << 16) | SourceId.Uint16;
-      PERF_END_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
-      );
+    // PERF_CODE (
+    //   Identifier = (Segment << 16) | SourceId.Uint16;
+    //   PERF_END_EX (gImageHandle, PerfToken, "IntelVTD", 0, Identifier);
+    //   );
+    PERF_INMODULE_END(PerfToken);
+    //MU_CHANGE End - Remove custom perf identifier
   }
 
   if (!EFI_ERROR (Status)) {


### PR DESCRIPTION
## Description

Remove custom identifiers for perf records so that we can decode perf for analysis.

Cherry-picked from https://github.com/microsoft/mu_silicon_intel_tiano/commit/750267e11fe992a060a5d7c5a622651711d5de41. Missed originally because line endings had changed, causing cleansing fire to show this as 0 lines changed.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.