### PR TITLE
Fixing CI break for new version of mu_tiano_plus.

### DIFF
--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
@@ -57,6 +57,7 @@
 
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf   # MU_CHANGE: /GS and -fstack-protector support
+  Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf ## MU_CHANGE
 
 [LibraryClasses.common.PEIM,LibraryClasses.common.PEI_CORE]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf


### PR DESCRIPTION
## Description

MU_TIANO_PLUS modified Tpm2DeviceLibDTpm to require Tpm2DebugLib, and created Tpm2DebugLib.

Initial CI could not bring in Tpm2DebugLib in IntelFsp2WrapperPkg because it did not exist at that time.

828318308d

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Local CI on IntelFsp2WrapperPkg is passing after this change. Failing prior with `Instance of library class [Tpm2DebugLib] is not found`.

## Integration Instructions
N/A