### PR TITLE
pip: Update all pip-requirements to latest

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,9 +12,9 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.21.8
-edk2-pytool-extensions~=0.27.10
-antlr4-python3-runtime==4.13.1
+edk2-pytool-library==0.21.10
+edk2-pytool-extensions~=0.27.11
+antlr4-python3-runtime==4.13.2
 lcov-cobertura==2.0.2
-regex
+regex==2024.7.24
 pygount==1.8.0


### PR DESCRIPTION
## Description

edk2-pytool-library from 0.21.8 to 0.21.10
edk2-pytool-extensions from 0.27.10 to 0.27.11
antlr4-python3-runtime from 4.13.1 to 4.13.2
regex from floating to 2024.7.24

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
CI.

## Integration Instructions
N/A