### PR TITLE
CI: Limit CI runs to AARCH64, IA32, X64.

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -16,7 +16,7 @@
 ##
 
 variables:
-- group: architectures-arm-64-x86-64
+- group: architectures-arm64-x86-64
 - group: tool-chain-ubuntu-gcc
 
 extends:


### PR DESCRIPTION
## Description
Remove ARM as a target for CI runs.

Only target AARCH64, IA32, X64 for GCC CI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Local CI builds. 

## Integration Instructions
Not Applicable since it is a CI change. 