### PR TITLE
IntelFsp2WrapperPkg: Remove TpmDebugLib instance.

### DIFF
--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dsc
@@ -57,7 +57,6 @@
 
   Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
   NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf   # MU_CHANGE: /GS and -fstack-protector support
-  Tpm2DebugLib|SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibNull.inf ## MU_CHANGE
 
 [LibraryClasses.common.PEIM,LibraryClasses.common.PEI_CORE]
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf


### PR DESCRIPTION

## Description

TpmDebugLib was removed in the dev/202502 branch (not in release). Remove the reference for the instance for the dev/202502 branch of mu_silicon_intel_tiano.



- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Local CI failed when pulling floating version of mu_silicon_intel_tiano.

## Integration Instructions
No integration ncesssary.