### PR TITLE
[CHERRY-PICK] Add Intel FIT Type A (TXT) Definitions [Rebase & FF]

### DIFF
--- a/IntelSiliconPkg/Include/IndustryStandard/FirmwareInterfaceTable.h
+++ b/IntelSiliconPkg/Include/IndustryStandard/FirmwareInterfaceTable.h
@@ -111,6 +111,29 @@ typedef struct {
   UINT8     ExtFamilyMask     : 4;  ///< Processor extended family field mask.
 } FIT_TYPE_02_VERSION_200_ENTRY;
 
+typedef struct {
+  UINT16    IndexPort;   // IO port (0x70 typically)
+  UINT16    DataPort;    // IO port (0x71 typically)
+  UINT8     AccessWidth; // 1, 2, or 4 bytes
+  UINT8     BitPosition; // Bit position within the CMOS byte (e.g. 15 => Bit 15)
+  UINT16    CmosIndex;   // CMOS index (e.g., 0x2A)
+} INDEX_IO_ADDRESS;
+
+typedef union {
+  UINT64              MemoryAddress;  // Must be under 4 GB. BIT0 at the addrress holds the TXT Configuration Policy.
+  INDEX_IO_ADDRESS    IoAddress;      // IO port address information to read the TXT Configuration Policy.
+} TXT_POLICY_PTR;
+
+typedef struct {
+  TXT_POLICY_PTR    Address;     // Address pointer to the TXT Policy structure
+  UINT8             Size[3];     // Optional, often 0x00 for Type A
+  UINT8             Reserved;    // Reserved must be set to 0
+  UINT16            Version;     // Version field (usually 0x0000)
+  UINT8             Type : 7;    // FIT entry type = 0x0A (TXT Policy)
+  UINT8             Cv   : 1;    // C_V[7], checksum/flags in some docs
+  UINT8             Checksum;    // Checksum for FIT entry
+} FIT_TYPE_0A_ENTRY;
+
 #pragma pack ()
 
 #endif

--- a/IntelSiliconPkg/Include/IndustryStandard/FirmwareInterfaceTable.h
+++ b/IntelSiliconPkg/Include/IndustryStandard/FirmwareInterfaceTable.h
@@ -119,9 +119,17 @@ typedef struct {
   UINT16    CmosIndex;   // CMOS index (e.g., 0x2A)
 } INDEX_IO_ADDRESS;
 
+typedef struct {
+  UINT32    TpmNvIndexHandle;     // TPM NV index handle
+  UINT8     FieldWidthInBytes;    // = 1 - 1-byte width, = 2 - 2-byte width
+  UINT8     StartingBitPosition;  // e.g. = 7 - BIT7
+  UINT16    ByteOffset;           // Offset within NV index, e.g. = 1 - byte 1
+} INDEX_TPM_ADDRESS;
+
 typedef union {
-  UINT64              MemoryAddress;  // Must be under 4 GB. BIT0 at the addrress holds the TXT Configuration Policy.
-  INDEX_IO_ADDRESS    IoAddress;      // IO port address information to read the TXT Configuration Policy.
+  UINT64               MemoryAddress; // Must be under 4 GB. BIT0 at the address holds the TXT Configuration Policy.
+  INDEX_IO_ADDRESS     IoAddress;     // IO port address information to read the TXT Configuration Policy.
+  INDEX_TPM_ADDRESS    TpmAddress;    // TPM NV index address information to read the TXT Configuration Policy.
 } TXT_POLICY_PTR;
 
 typedef struct {


### PR DESCRIPTION
## Description

**IntelSiliconPkg: Add FIT Record 0xA (TXT Policy) definition**

Adds the FIT Record type 0xA definition for Intel TXT Policy in the
Firmware Interface Table (FIT) header file based on its definition
in the v1.2 Intel Firmware Interface Table Specification.

(cherry picked from commit b9eb4f09d52abe3703bceacbd329035fdca989b4)

---

**IntelSiliconPkg: Add INDEX_TPM_ADDRESS to FIT Record A**

Adds the definition for INDEX_TPM_ADDRESS in the FIT Record A
TXT_POLICY_PTR structure as per Intel Firmware Interface Table
Specification.

(cherry picked from commit 288c97aa668d415f3c1f70d338e016bb16144a13)

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- IntelSiliconPkg CI

## Integration Instructions

- Review the Intel FIT Specification v1.2 to find these definitions
- Update code as necessary to use the appropriate Type Record 0xA variation based on platform usage