### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,8 @@ updates:
       - "type:dependencies"
       - "type:dependabot"
     rebase-strategy: "disabled"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -29,5 +29,5 @@ jobs:
 
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/AutoApprover.yml@bc161dc1de33e44b23acdd041f1875993dd68e86 # v13.0.3
     secrets: inherit

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,5 +32,5 @@ jobs:
 
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'uefibot'
-    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@v13.0.3
+    uses: microsoft/mu_devops/.github/workflows/AutoMerger.yml@bc161dc1de33e44b23acdd041f1875993dd68e86 # v13.0.3
     secrets: inherit

--- a/.github/workflows/backport-to-release-branch.yml
+++ b/.github/workflows/backport-to-release-branch.yml
@@ -43,20 +43,20 @@ jobs:
     steps:
     - name: Generate Token
       id: app-token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
       with:
         app-id: ${{ vars.MU_ACCESS_APP_ID }}
         private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
 
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       with:
         fetch-depth: 0
         token: ${{ steps.app-token.outputs.token }}
 
     - name: Determine Contribution Info
       id: backport_info
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           const BOLD = "\u001b[1m";
@@ -96,7 +96,7 @@ jobs:
 
     - name: Check if Backport is Requested
       id: backport_check
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           if (${{ steps.backport_info.outputs.backport_needed }} === 'false') {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,12 +49,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
 
 
     - name: Install Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.12'
 
@@ -101,12 +101,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
 
 
     - name: Install Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -232,7 +232,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.12
+      uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'
@@ -273,7 +273,7 @@ jobs:
       run: stuart_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Setup Log As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: (success() || failure()) && steps.get_ci_file_operations.outputs.setup_supported == 'true'
       with:
         name: ${{ matrix.package }}-Setup-Log
@@ -287,7 +287,7 @@ jobs:
       run: stuart_ci_setup -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload CI Setup Log As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: (success() || failure()) && steps.get_ci_file_operations.outputs.ci_setup_supported == 'true'
       with:
         name: ${{ matrix.package }}-CI-Setup-Log
@@ -300,7 +300,7 @@ jobs:
       run: stuart_update -c .pytool/CISettings.py -t DEBUG -a ${{ matrix.archs }} TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }}
 
     - name: Upload Update Log As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success() || failure()
       with:
         name: ${{ matrix.package }}-Update-Log
@@ -366,7 +366,7 @@ jobs:
 
     - name: Attempt to Load CodeQL CLI From Cache
       id: codeqlcli_cache
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.cache_key_gen.outputs.codeql_cli_ext_dep_dir }}
         key: ${{ steps.cache_key_gen.outputs.codeql_cli_cache_key }}
@@ -452,7 +452,7 @@ jobs:
         delete_dirs(build_path)
 
     - name: Upload Build Logs As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success() || failure()
       with:
         name: ${{ matrix.package }}-Build-Logs
@@ -483,7 +483,7 @@ jobs:
             print(f'sarif_file_path={sarif_path}', file=fh)
 
     - name: Upload CodeQL Results (SARIF) As An Artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ matrix.package }}-CodeQL-SARIF
         path: ${{ steps.env_data.outputs.sarif_file_path }}
@@ -491,7 +491,7 @@ jobs:
         if-no-files-found: warn
 
     - name: Upload CodeQL Results (SARIF) To GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         # Path to SARIF file relative to the root of the repository.
         sarif_file: ${{ steps.env_data.outputs.sarif_file_path }}
@@ -512,7 +512,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Create Empty SARIF
       shell: python
@@ -539,7 +539,7 @@ jobs:
             json.dump(sarif, f)
 
     - name: Upload Empty SARIF To GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         sarif_file: empty.sarif
         category: no-packages

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -19,5 +19,5 @@ on:
 jobs:
   apply:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@v18.0.3
+    uses: microsoft/mu_devops/.github/workflows/IssueAssignment.yml@b0137779778b6b873c8356a20ed8361dbda46666 # v18.0.3
     secrets: inherit

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -31,5 +31,5 @@ on:
 
 jobs:
   apply:
-    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@v18.0.3
+    uses: microsoft/mu_devops/.github/workflows/Labeler.yml@b0137779778b6b873c8356a20ed8361dbda46666 # v18.0.3
     secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   sync:
 
-    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@v18.0.3
+    uses: microsoft/mu_devops/.github/workflows/LabelSyncer.yml@b0137779778b6b873c8356a20ed8361dbda46666 # v18.0.3
     secrets: inherit

--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Check for Validation Errors
         if: env.VALIDATION_ERROR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             core.setFailed('PR Formatting Validation Check Failed!')

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -29,5 +29,5 @@ jobs:
   draft:
     name: Draft Releases
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v18.0.3
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@b0137779778b6b873c8356a20ed8361dbda46666 # v18.0.3
     secrets: inherit

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.MU_ACCESS_APP_ID }}
           private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,5 @@ on:
 jobs:
   check:
 
-    uses: microsoft/mu_devops/.github/workflows/Stale.yml@v18.0.3
+    uses: microsoft/mu_devops/.github/workflows/Stale.yml@b0137779778b6b873c8356a20ed8361dbda46666 # v18.0.3
     secrets: inherit

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -20,5 +20,5 @@ on:
 jobs:
   triage:
 
-    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@v18.0.3
+    uses: microsoft/mu_devops/.github/workflows/IssueTriager.yml@b0137779778b6b873c8356a20ed8361dbda46666 # v18.0.3
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
